### PR TITLE
Giving custom errorHandlers access to the SC.Resource model.

### DIFF
--- a/spec/javascripts/resourceSpec.js
+++ b/spec/javascripts/resourceSpec.js
@@ -1,5 +1,5 @@
 describe('A Resource instance', function() {
-  var Model, model;
+  var Model, model, server;
 
   beforeEach(function() {
     Model = SC.Resource.define({
@@ -71,4 +71,35 @@ describe('A Resource instance', function() {
       expect(model.get('subject')).toBe('bar');
     });
   });
+
+  describe('SC.Resource.ajax', function() {
+    beforeEach(function() {
+      server = sinon.fakeServer.create();
+    });
+
+    afterEach(function() {
+      server.restore();
+      SC.Resource.errorHandler = null;
+    });
+
+    describe('handling errors on save', function() {
+      beforeEach(function() {
+        server.respondWith('POST', '/people', [422, {}, '[["foo", "bar"]]']);
+      });
+
+      it('should pass a reference to the resource to the error handling function', function() {
+        var spy = jasmine.createSpy();
+        SC.Resource.errorHandler = function(a, b, c, fourthArgument) {
+          spy(fourthArgument);
+        }
+
+        var resource = Model.create({ name: 'foo' });
+        resource.save();
+        server.respond();
+
+        expect(spy).toHaveBeenCalledWith(resource);
+      });
+    });
+  });
+
 });

--- a/src/sproutcore-resource.js
+++ b/src/sproutcore-resource.js
@@ -460,6 +460,7 @@
     if (!options.error && SC.Resource.errorHandler) {
       if (options.resource) {
         options.error = errorHandlerWithModel(SC.Resource.errorHandler, options.resource);
+        delete options.resource;
       } else {
         options.error = SC.Resource.errorHandler;
       }

--- a/src/sproutcore-resource.js
+++ b/src/sproutcore-resource.js
@@ -433,23 +433,23 @@
   });
 
 
-  // Gives you access to `model` in your custom `errorHandler` methods.
-  // 1. `this` will refer to the model object.
-  // 2. `model` will be passed as the last argument
+  // Gives custom error handlers access to the resource object.
+  // 1. `this` will refer to the SC.Resource object.
+  // 2. `resource` will be passed as the last argument
   //
   //     function errorHandler() {
-  //       this; // the model
+  //       this; // the SC.Resource
   //     }
   //
-  //     function errorHandler(jqXHR, textStatus, errorThrown, model) {
-  //       model; // another way to reference the model
+  //     function errorHandler(jqXHR, textStatus, errorThrown, resource) {
+  //       resource; // another way to reference the resource object
   //     }
   //
-  var errorHandlerWithModel = function(errorHandler, model) {
+  var errorHandlerWithModel = function(errorHandler, resource) {
     return function() {
       var args = Array.prototype.slice.call(arguments, 0);
-      args.push(model);
-      errorHandler.apply(model, args);
+      args.push(resource);
+      errorHandler.apply(resource, args);
     }
   };
 
@@ -458,8 +458,8 @@
     options.type     = options.type     || 'GET';
 
     if (!options.error && SC.Resource.errorHandler) {
-      if (options.model) {
-        options.error = errorHandlerWithModel(SC.Resource.errorHandler, options.model);
+      if (options.resource) {
+        options.error = errorHandlerWithModel(SC.Resource.errorHandler, options.resource);
       } else {
         options.error = SC.Resource.errorHandler;
       }
@@ -611,7 +611,7 @@
     save: function() {
       var ajaxOptions = {
         data: this.toJSON(),
-        model: this
+        resource: this
       };
 
       if (SC.get(this, 'isNew')) {


### PR DESCRIPTION
Gives you access to `model` in your custom `errorHandler` methods.
1. `this` will refer to the model object.
2. `model` will be passed as the last argument

```
function errorHandler() {
  this; // the model
}

function errorHandler(jqXHR, textStatus, errorThrown, model) {
  model; // another way to reference the model
}
```

/cc @staugaard, @shajith
