### PR TITLE
Autofetch switch

### DIFF
--- a/spec/javascripts/autoFetchingSpec.js
+++ b/spec/javascripts/autoFetchingSpec.js
@@ -41,7 +41,7 @@ describe('Auto fetching', function() {
       });
     });
 
-    it('getting unknown attributes should not schedule a fetch', function() {
+    it('getting known attributes that are not defined should schedule a fetch', function() {
       runs(function() {
         expect(person.get('name')).toBeUndefined();
       });
@@ -51,6 +51,19 @@ describe('Auto fetching', function() {
       runs(function() {
         server.respond();
         expect(person.get('name')).toBe('Mick Staugaard');
+      });
+    });
+
+    it('getting unknown attributes should not schedule a fetch', function() {
+      spyOn(person, 'fetch');
+      runs(function() {
+        expect(person.get('notInSchema')).toBeUndefined();
+      });
+
+      waits(100);
+
+      runs(function() {
+        expect(person.fetch).not.toHaveBeenCalled();
       });
     });
   });

--- a/spec/javascripts/autoFetchingSpec.js
+++ b/spec/javascripts/autoFetchingSpec.js
@@ -81,6 +81,17 @@ describe('Auto fetching', function() {
         expect(person.fetch).not.toHaveBeenCalled();
       });
     });
+
+    it('should not observe clock ticks when autoFetch is false', function() {
+      spyOn(person, 'updateIsExpired');
+      person.set('autoFetch', false);
+
+      Ember.Resource.Lifecycle.clock.tick();
+      person.set('expireAt', new Date());
+      person.set('resourceState', Ember.Resource.Lifecycle.DESTOYING);
+
+      expect(person.updateIsExpired).not.toHaveBeenCalled();
+    });
   });
 
   describe('of collections', function() {

--- a/spec/javascripts/autoFetchingSpec.js
+++ b/spec/javascripts/autoFetchingSpec.js
@@ -66,6 +66,21 @@ describe('Auto fetching', function() {
         expect(person.fetch).not.toHaveBeenCalled();
       });
     });
+
+    it('should not fetch when autoFetch is false', function() {
+      spyOn(person, 'fetch');
+      person.set('autoFetch', false);
+
+      runs(function() {
+        expect(person.get('name')).toBeUndefined();
+      });
+
+      waits(100);
+
+      runs(function() {
+        expect(person.fetch).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('of collections', function() {

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -627,6 +627,7 @@
     prototypeMixin: Ember.Mixin.create({
       expireIn: 60 * 5,
       resourceState: 0,
+      autoFetch: true,
 
       init: function() {
         this._super.apply(this, arguments);
@@ -665,6 +666,10 @@
         return state == Ember.Resource.Lifecycle.UNFETCHED || state === Ember.Resource.Lifecycle.EXPIRED;
       }.property('resourceState').cacheable(),
 
+      isAutoFetchable: function() {
+        return this.get('isFetchable') && this.get('autoFetch');
+      }.property('isFetchable', 'autoFetch').cacheable(),
+
       isInitializing: function() {
         return (Ember.get(this, 'resourceState') || Ember.Resource.Lifecycle.INITIALIZING) === Ember.Resource.Lifecycle.INITIALIZING;
       }.property('resourceState').cacheable(),
@@ -690,7 +695,7 @@
       }.property('resourceState').cacheable(),
 
       scheduleFetch: function() {
-        if (Ember.get(this, 'isFetchable')) {
+        if (Ember.get(this, 'isAutoFetchable')) {
           Ember.run.next(this, this.fetch);
         }
       },


### PR DESCRIPTION
Set `autoFetch: false` on a resource to turn auto-fetching off. Bonus: observers aren't bound if `autoFetch` is `false`.
