### PR TITLE
DESTOYING typo

### DIFF
--- a/spec/javascripts/autoFetchingSpec.js
+++ b/spec/javascripts/autoFetchingSpec.js
@@ -88,7 +88,7 @@ describe('Auto fetching', function() {
 
       Ember.Resource.Lifecycle.clock.tick();
       person.set('expireAt', new Date());
-      person.set('resourceState', Ember.Resource.Lifecycle.DESTOYING);
+      person.set('resourceState', Ember.Resource.Lifecycle.DESTROYING);
 
       expect(person.updateIsExpired).not.toHaveBeenCalled();
     });

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -586,7 +586,7 @@
     FETCHING:     40,
     FETCHED:      50,
     SAVING:       60,
-    DESTOYING:    70,
+    DESTROYING:   70,
     DESTROYED:    80,
 
     clock: Ember.Object.create({
@@ -690,7 +690,7 @@
           Ember.Resource.Lifecycle.INITIALIZING,
           Ember.Resource.Lifecycle.FETCHING,
           Ember.Resource.Lifecycle.SAVING,
-          Ember.Resource.Lifecycle.DESTOYING
+          Ember.Resource.Lifecycle.DESTROYING
         ];
 
         return state && !unsavableState.contains(state);


### PR DESCRIPTION
Changed to DESTROYING in the two places it is used.
