### PR TITLE
Revert "Lifecycle: don't bind observers if autoFetch is false"

### DIFF
--- a/spec/javascripts/autoFetchingSpec.js
+++ b/spec/javascripts/autoFetchingSpec.js
@@ -81,17 +81,6 @@ describe('Auto fetching', function() {
         expect(person.fetch).not.toHaveBeenCalled();
       });
     });
-
-    it('should not observe clock ticks when autoFetch is false', function() {
-      spyOn(person, 'updateIsExpired');
-      person.set('autoFetch', false);
-
-      Ember.Resource.Lifecycle.clock.tick();
-      person.set('expireAt', new Date());
-      person.set('resourceState', Ember.Resource.Lifecycle.DESTROYING);
-
-      expect(person.updateIsExpired).not.toHaveBeenCalled();
-    });
   });
 
   describe('of collections', function() {

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -640,8 +640,6 @@
           Ember.set(self, 'expireAt', expireAt);
         };
 
-        this.toggleAutoFetchObservers();
-
         Ember.addListener(this, 'willFetch', this, function() {
           Ember.set(self, 'resourceState', Ember.Resource.Lifecycle.FETCHING);
           updateExpiry();
@@ -709,16 +707,6 @@
         });
       },
 
-      // If the resource is to be auto-fetched, clock ticks and changes to
-      // the resource's lifecycle states to the auto-fetch. If not, remove
-      // the observers so we don't pay a performance penalty.
-      toggleAutoFetchObservers: function() {
-        var toggle = $.proxy(this.get('autoFetch') ? Ember.addObserver : Ember.removeObserver, Ember);
-        toggle(Ember.Resource.Lifecycle, 'clock.now',     this, 'updateIsExpired');
-        toggle(this,                     'expireAt',      this, 'updateIsExpired');
-        toggle(this,                     'resourceState', this, 'updateIsExpired');
-      }.observes('autoFetch'),
-
       updateIsExpired: function() {
         var isExpired = Ember.get(this, 'resourceState') === Ember.Resource.Lifecycle.EXPIRED;
         if (isExpired) return true;
@@ -732,7 +720,7 @@
         if (isExpired !== Ember.get(this, 'isExpired')) {
           Ember.set(this, 'isExpired', isExpired);
         }
-      },
+      }.observes('Ember.Resource.Lifecycle.clock.now', 'expireAt', 'resourceState'),
 
       isExpired: function(name, value) {
         if (value) {


### PR DESCRIPTION
We were trying to add some premature optimization. Turns out if these observers are not present, resources will never be marked expired.
