### PR TITLE
Add in missing resource on destroy

### DIFF
--- a/spec/javascripts/destroySpec.js
+++ b/spec/javascripts/destroySpec.js
@@ -1,0 +1,40 @@
+describe('Destroying a resource instance', function() {
+  var Model, model, server;
+
+  beforeEach(function() {
+    Model = Ember.Resource.define({
+      schema: {
+        id:       Number,
+        name:     String,
+        subject:  String
+      },
+      url: '/people'
+    });
+
+    server = sinon.fakeServer.create();
+  });
+
+  afterEach(function() {
+    server.restore();
+    Ember.Resource.errorHandler = null;
+  });
+
+  describe('handling errors on destroy', function() {
+    beforeEach(function() {
+      server.respondWith('DELETE', '/people', [422, {}, '[["foo", "bar"]]']);
+    });
+
+    it('should pass a reference to the resource to the error handling function', function() {
+      var spy = jasmine.createSpy();
+      Ember.Resource.errorHandler = function(a, b, c, fourthArgument) {
+        spy(fourthArgument);
+      };
+
+      var resource = Model.create({ name: 'f0o' });
+      resource.destroy();
+      server.respond();
+
+      expect(spy).toHaveBeenCalledWith(resource);
+    });
+  });
+});

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -857,7 +857,8 @@
       Ember.set(this, 'resourceState', Ember.Resource.Lifecycle.DESTROYING);
       return Ember.Resource.ajax({
         type: 'DELETE',
-        url:  this.resourceURL()
+        url:  this.resourceURL(),
+        resource: this
       }).done(function() {
         Ember.set(self, 'resourceState', Ember.Resource.Lifecycle.DESTROYED);
       }).fail(function() {


### PR DESCRIPTION
When saving a resource, the resource model is passed up to the error handler.
This commit ensures the resource model is passed to the error handler on destroy as well.
