### PR TITLE
ResourceCollection will read it's `url` property.

### DIFF
--- a/spec/javascripts/resourceCollectionSpec.js
+++ b/spec/javascripts/resourceCollectionSpec.js
@@ -1,0 +1,21 @@
+/*globals Em*/
+
+describe('ResourceCollection', function() {
+
+  it("reads from it's url property if present", function() {
+    var Model = Em.Resource.define({
+      url: '/url/from/resource'
+    });
+
+    var collection = Em.ResourceCollection.create({
+      type: Model,
+
+      url: function() {
+        return '/foo';
+      }.property().cacheable()
+    });
+
+    expect(collection.resolveUrl()).toEqual('/foo');
+  });
+
+});

--- a/spec/javascripts/resourceCollectionSpec.js
+++ b/spec/javascripts/resourceCollectionSpec.js
@@ -11,11 +11,11 @@ describe('ResourceCollection', function() {
       type: Model,
 
       url: function() {
-        return '/foo';
+        return '/url/from/collection';
       }.property().cacheable()
     });
 
-    expect(collection.resolveUrl()).toEqual('/foo');
+    expect(collection.resolveUrl()).toEqual('/url/from/collection');
   });
 
 });

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -1085,9 +1085,12 @@
     _fetch: function(callback) {
       this._resolveType();
       return Ember.Resource.ajax({
-        url: this.url || this.type.resourceURL(),
+        url: this.resolveUrl(),
         success: callback
       });
+    },
+    resolveUrl: function() {
+      return this.get('url') || this.type.resourceURL();
     },
     instantiateItems: function(items) {
       this._resolveType();


### PR DESCRIPTION
Previously ResourceCollection was only looking at `this.url`. However, if the url is defined as a computed property ResourceCollection would totally overlook it. Now it will check the computed property as well.
