### PR TITLE
Setting dates using toString() so they work on ci servers.

### DIFF
--- a/dist/ember-resource.js
+++ b/dist/ember-resource.js
@@ -534,7 +534,11 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
         value = this.typeCast(value);
       }
       if (value !== null && value !== undefined && Ember.typeOf(value.toJSON) == 'function') {
-        value = value.toJSON();
+        if (Ember.typeOf(value) === 'date') {
+          value = value.toString();
+        } else {
+          value = value.toJSON();
+        }
       }
       Ember.Resource.deepSet(data, this.get('path'), value);
     },

--- a/dist/ember-resource.js
+++ b/dist/ember-resource.js
@@ -533,10 +533,10 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
       if (this.typeCast) {
         value = this.typeCast(value);
       }
-      if (value !== null && value !== undefined && Ember.typeOf(value.toJSON) == 'function') {
-        if (Ember.typeOf(value) === 'date') {
+      if (value !== null && value !== undefined) {
+        if (Ember.typeOf(value) === 'date' && Ember.typeOf(value.toString) === 'function') {
           value = value.toString();
-        } else {
+        } else if (Ember.typeOf(value.toJSON) == 'function') {
           value = value.toJSON();
         }
       }

--- a/spec/javascripts/schemaSpec.js
+++ b/spec/javascripts/schemaSpec.js
@@ -145,7 +145,7 @@ describe('schema definition', function() {
   it('should create Date properties', function() {
     var date = new Date();
     var dateString = date.toJSON();
-    
+
     var Model = Ember.Resource.define({
       schema: {
         createdAt: Date,
@@ -164,9 +164,17 @@ describe('schema definition', function() {
 
     instance.set('createdAt', date);
     expect(instance.getPath('data.createdAt')).toEqual(dateString, "convert a Date instance to a string");
-    
+
     instance.set('updatedAt', dateString);
     expect(instance.getPath('data.updatedAt')).toEqual(dateString, 'convert a string ("' + dateString + '") to a string');
+  });
+
+  it('shold set and retrieve dates properly', function() {
+    var date = new Date();
+    var Model = Em.Resource.define({ schema: { birthday: Date } });
+    var model = Model.create();
+    model.set('birthday', date);
+    expect(date.toJSON()).toEqual(model.get('birthday').toJSON());
   });
 
   it('should create Boolean properties', function() {

--- a/spec/javascripts/schemaSpec.js
+++ b/spec/javascripts/schemaSpec.js
@@ -160,7 +160,7 @@ describe('schema definition', function() {
     expect(instance.get('updatedAt')).toEqual(date);
 
     date = new Date();
-    dateString = date.toJSON();
+    dateString = date.toString();
 
     instance.set('createdAt', date);
     expect(instance.getPath('data.createdAt')).toEqual(dateString, "convert a Date instance to a string");
@@ -174,7 +174,7 @@ describe('schema definition', function() {
     var Model = Em.Resource.define({ schema: { birthday: Date } });
     var model = Model.create();
     model.set('birthday', date);
-    expect(date.toJSON()).toEqual(model.get('birthday').toJSON());
+    expect(date.toString()).toEqual(model.get('birthday').toString());
   });
 
   it('should create Boolean properties', function() {

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -174,10 +174,10 @@
       if (this.typeCast) {
         value = this.typeCast(value);
       }
-      if (value !== null && value !== undefined && Ember.typeOf(value.toJSON) == 'function') {
-        if (Ember.typeOf(value) === 'date') {
+      if (value !== null && value !== undefined) {
+        if (Ember.typeOf(value) === 'date' && Ember.typeOf(value.toString) === 'function') {
           value = value.toString();
-        } else {
+        } else if (Ember.typeOf(value.toJSON) == 'function') {
           value = value.toJSON();
         }
       }

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -175,7 +175,11 @@
         value = this.typeCast(value);
       }
       if (value !== null && value !== undefined && Ember.typeOf(value.toJSON) == 'function') {
-        value = value.toJSON();
+        if (Ember.typeOf(value) === 'date') {
+          value = value.toString();
+        } else {
+          value = value.toJSON();
+        }
       }
       Ember.Resource.deepSet(data, this.get('path'), value);
     },


### PR DESCRIPTION
Currently the `setValue` method accepts a value and calls `toJSON` on it before it is stored. Unfortunately, jasmine headless webkit can not properly run this line of code:

```
new Date(new Date().toJSON()); // "Invalid Date"
```

However, if we use `toString` to serialize dates, then jasmine headless webkit can properly deal with these date objects.

Cons:
- Using `toString` is accurate only to a whole second. `toJSON` will serialize and preserve accuracy down to the millisecond.
