### PR TITLE
When changing data, notify properties will change

### DIFF
--- a/dist/ember-resource.js
+++ b/dist/ember-resource.js
@@ -390,7 +390,9 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
         Ember.set(obj, key, newObj);
       }
 
+      Ember.propertyWillChange(newObj, path);
       Ember.Resource.deepSet(newObj, path, value);
+      Ember.propertyDidChange(newObj, path);
     }
   };
 
@@ -403,7 +405,9 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
         newValue = Ember.get(objB, key);
 
         if (Ember.typeOf(newValue) === 'object' && Ember.typeOf(oldValue) === 'object') {
+          Ember.propertyWillChange(objA, key);
           Ember.Resource.deepMerge(oldValue, newValue);
+          Ember.propertyDidChange(objA, key);
         } else {
           Ember.set(objA, key, newValue);
         }

--- a/spec/javascripts/saveSpec.js
+++ b/spec/javascripts/saveSpec.js
@@ -149,6 +149,35 @@ describe('Saving a resource instance', function() {
         expect(resource.get('subject')).toBeUndefined();
         expect(resource.get('name')).toBe('foo');
       })
+
+      describe('resource has one embedded association', function() {
+        beforeEach(function() {
+          var Address = Ember.Resource.define({
+            schema: {
+              street: String,
+              zip:    Number,
+              city:   String
+            }
+          });
+          var Person = Ember.Resource.define({
+            schema: {
+              id:   Number,
+              name: String,
+              address: {type: Address, nested: true}
+            },
+            url: '/persons'
+          });
+          server.respondWith('POST', '/persons', [201, { "Content-Type": "application/json" }, '{ "id": 1, "address": { "street": "baz" } }']);
+          resource = Person.create({ name: 'foo' }, { address: { street: 'bar' } });
+        });
+
+        it("should update with the data given", function() {
+          resource.save();
+          server.respond();
+          expect(resource.get('id')).toBe(1);
+          expect(resource.getPath('address.street')).toBe('baz');
+        });
+      });
     });
 
   });

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -31,7 +31,9 @@
         Ember.set(obj, key, newObj);
       }
 
+      Ember.propertyWillChange(newObj, path);
       Ember.Resource.deepSet(newObj, path, value);
+      Ember.propertyDidChange(newObj, path);
     }
   };
 
@@ -44,7 +46,9 @@
         newValue = Ember.get(objB, key);
 
         if (Ember.typeOf(newValue) === 'object' && Ember.typeOf(oldValue) === 'object') {
+          Ember.propertyWillChange(objA, key);
           Ember.Resource.deepMerge(oldValue, newValue);
+          Ember.propertyDidChange(objA, key);
         } else {
           Ember.set(objA, key, newValue);
         }


### PR DESCRIPTION
Problem: `data` is a hash, and Ember doesn't notify when nested properties of a hash change. That means for example, if a resource has one embedded association, and after a fetch some property of this association changes, the cacheable property (association name) won't be notified and will still return an old value. i.e.:

```
var obj = Em.Object.create({ 
  data: { association: { name: 'foo' } }, 
  observesHash: function() { console.log('changed!'); }.observes('data')
});
obj.setPath('data.association.name', 'bar');
// => Class {__ember1352744516303_meta: Object}
obj.setPath('data', {});
// => changed! 
// => Class {__ember1352744516303_meta: Object}
```

/cc @shajith
