### PR TITLE
Not overriding Em.Object's destroy

### DIFF
--- a/dist/ember-resource.js
+++ b/dist/ember-resource.js
@@ -1261,7 +1261,7 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
       return deferedSave;
     },
 
-    destroy: function() {
+    destroyResource: function() {
       var previousState = Ember.get(this, 'resourceState'), self = this;
       Ember.set(this, 'resourceState', Ember.Resource.Lifecycle.DESTROYING);
       return Ember.Resource.ajax({
@@ -1271,6 +1271,7 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
         resource: this
       }).done(function() {
         Ember.set(self, 'resourceState', Ember.Resource.Lifecycle.DESTROYED);
+        self.destroy();
       }).fail(function() {
         Ember.set(self, 'resourceState', previousState);
       });

--- a/spec/javascripts/destroySpec.js
+++ b/spec/javascripts/destroySpec.js
@@ -31,8 +31,8 @@ describe('Destroying a resource instance', function() {
         spy(fourthArgument.resource, fourthArgument.operation);
       };
 
-      var resource = Model.create({ name: 'f0o' });
-      resource.destroy();
+      var resource = Model.create({ id: 1, name: 'f0o' });
+      resource.destroyResource();
       server.respond();
 
       expect(spy).toHaveBeenCalledWith(resource, "destroy");

--- a/spec/javascripts/lifecycleSpec.js
+++ b/spec/javascripts/lifecycleSpec.js
@@ -69,7 +69,7 @@ describe('Lifecycle', function() {
         fiveMinutesFromNow.setSeconds(fiveMinutesFromNow.getSeconds() + (60 * 5));
 
         expect(person.get('expireAt')).toBeDefined();
-        expect(person.get('expireAt').getTime()).toBeCloseTo(fiveMinutesFromNow.getTime(), 1000);
+        expect(person.get('expireAt').getTime()).toBeCloseTo(fiveMinutesFromNow.getTime(), 2);
       });
     });
 

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -902,7 +902,7 @@
       return deferedSave;
     },
 
-    destroy: function() {
+    destroyResource: function() {
       var previousState = Ember.get(this, 'resourceState'), self = this;
       Ember.set(this, 'resourceState', Ember.Resource.Lifecycle.DESTROYING);
       return Ember.Resource.ajax({
@@ -912,6 +912,7 @@
         resource: this
       }).done(function() {
         Ember.set(self, 'resourceState', Ember.Resource.Lifecycle.DESTROYED);
+        self.destroy();
       }).fail(function() {
         Ember.set(self, 'resourceState', previousState);
       });


### PR DESCRIPTION
This renames Em.Resource's `destroy` to `destroyResource`. We need the regular `destroy` functionality to be available in a straightforward fashion.

/cc @staugaard
