### PR TITLE
Removing from identity map upon #destroy

### DIFF
--- a/dist/ember-resource.js
+++ b/dist/ember-resource.js
@@ -341,6 +341,10 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
       return LRUCache.prototype.put.apply(this.cache, arguments);
     },
 
+    remove: function() {
+      return LRUCache.prototype.remove.apply(this.cache, arguments);
+    },
+
     clear: function() {
       return LRUCache.prototype.removeAll.apply(this.cache, arguments);
     },
@@ -357,7 +361,8 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
 
   Ember.Resource.IdentityMap.DEFAULT_IDENTITY_MAP_LIMIT = 500;
 
-}());(function(exports) {
+}());
+(function(exports) {
 
   var expandSchema, expandSchemaItem, createSchemaProperties,
       mergeSchemas;
@@ -1259,6 +1264,13 @@ if (typeof this === 'object') this.LRUCache = LRUCache;
       });
 
       return deferedSave;
+    },
+
+    destroy: function() {
+      if(this.get('id')) {
+        this.constructor.identityMap.remove(this.get('id'));
+      }
+      this._super();
     },
 
     destroyResource: function() {

--- a/spec/javascripts/destroySpec.js
+++ b/spec/javascripts/destroySpec.js
@@ -19,7 +19,20 @@ describe('Destroying a resource instance', function() {
     Ember.Resource.errorHandler = null;
   });
 
-  describe('handling errors on destroy', function() {
+  describe('#destroy', function() {
+
+    beforeEach(function() {
+      model = Model.create({id: 1});
+      expect(Model.identityMap.get(1)).toEqual(model);
+      model.destroy();
+    });
+
+    it('should remove the object from the identity map', function() {
+      expect(Model.identityMap.get(1)).toBe(undefined);
+    });
+  });
+
+  describe('handling errors on resource destruction', function() {
     beforeEach(function() {
       server.respondWith('DELETE', '/people', [422, {}, '[["foo", "bar"]]']);
     });

--- a/src/ember-resource.js
+++ b/src/ember-resource.js
@@ -902,6 +902,13 @@
       return deferedSave;
     },
 
+    destroy: function() {
+      if(this.get('id')) {
+        this.constructor.identityMap.remove(this.get('id'));
+      }
+      this._super();
+    },
+
     destroyResource: function() {
       var previousState = Ember.get(this, 'resourceState'), self = this;
       Ember.set(this, 'resourceState', Ember.Resource.Lifecycle.DESTROYING);

--- a/src/identity_map.js
+++ b/src/identity_map.js
@@ -12,6 +12,10 @@
       return LRUCache.prototype.put.apply(this.cache, arguments);
     },
 
+    remove: function() {
+      return LRUCache.prototype.remove.apply(this.cache, arguments);
+    },
+
     clear: function() {
       return LRUCache.prototype.removeAll.apply(this.cache, arguments);
     },


### PR DESCRIPTION
Destroying a resource's backing Em.Object should remove it from the identity map, because once `isDestroyed` is true, it's no good for anything.
